### PR TITLE
Add new_from_memory / write_to_memory

### DIFF
--- a/tests/037.phpt
+++ b/tests/037.phpt
@@ -4,7 +4,7 @@ can make an image from memory
 <?php if (!extension_loaded("vips")) print "skip"; ?>
 --FILE--
 <?php
-  $binary_str = pack("c*", ...array_fill(0, 200, 0));
+  $binary_str = pack("C*", ...array_fill(0, 200, 0));
   $image = vips_image_new_from_memory($binary_str, 20, 10, 1, "uchar")["out"];
   $width = vips_image_get($image, "width")["out"];
   $height = vips_image_get($image, "height")["out"];

--- a/tests/037.phpt
+++ b/tests/037.phpt
@@ -4,8 +4,8 @@ can make an image from memory
 <?php if (!extension_loaded("vips")) print "skip"; ?>
 --FILE--
 <?php
-  $byte_array = array_fill(0, 200, 0);
-  $image = vips_image_new_from_memory($byte_array, 20, 10, 1, 'uchar')["out"];
+  $binary_str = pack("c*", ...array_fill(0, 200, 0));
+  $image = vips_image_new_from_memory($binary_str, 20, 10, 1, "uchar")["out"];
   $width = vips_image_get($image, "width")["out"];
   $height = vips_image_get($image, "height")["out"];
   $format = vips_image_get($image, "format")["out"];

--- a/tests/037.phpt
+++ b/tests/037.phpt
@@ -5,7 +5,7 @@ can make an image from memory
 --FILE--
 <?php
   $byte_array = array_fill(0, 200, 0);
-  $image = vips_image_new_from_memory($byte_array, 20, 10, 1, 'uchar');
+  $image = vips_image_new_from_memory($byte_array, 20, 10, 1, 'uchar')["out"];
   $width = vips_image_get($image, "width")["out"];
   $height = vips_image_get($image, "height")["out"];
   $format = vips_image_get($image, "format")["out"];

--- a/tests/037.phpt
+++ b/tests/037.phpt
@@ -15,8 +15,8 @@ can make an image from memory
   if ($width == 20 &&
 	$height == 10 &&
 	$format == 'uchar' &&
-    $bands == 1 &&
-    $avg == 0) {
+	$bands == 1 &&
+	$avg == 0) {
 	echo "pass";
   }
 ?>

--- a/tests/037.phpt
+++ b/tests/037.phpt
@@ -10,14 +10,13 @@ can make an image from memory
   $height = vips_image_get($image, "height")["out"];
   $format = vips_image_get($image, "format")["out"];
   $bands = vips_image_get($image, "bands")["out"];
-  // FIXME: $avg doesn't output zero.
   $avg = vips_call("avg", $image)["out"];
-  // echo $avg;
 
   if ($width == 20 &&
 	$height == 10 &&
 	$format == 'uchar' &&
-    $bands == 1) {
+    $bands == 1 &&
+    $avg == 0) {
 	echo "pass";
   }
 ?>

--- a/tests/037.phpt
+++ b/tests/037.phpt
@@ -1,0 +1,25 @@
+--TEST--
+can make an image from memory
+--SKIPIF--
+<?php if (!extension_loaded("vips")) print "skip"; ?>
+--FILE--
+<?php
+  $byte_array = array_fill(0, 200, 0);
+  $image = vips_image_new_from_memory($byte_array, 20, 10, 1, 'uchar');
+  $width = vips_image_get($image, "width")["out"];
+  $height = vips_image_get($image, "height")["out"];
+  $format = vips_image_get($image, "format")["out"];
+  $bands = vips_image_get($image, "bands")["out"];
+  // FIXME: $avg doesn't output zero.
+  $avg = vips_call("avg", $image)["out"];
+  // echo $avg;
+
+  if ($width == 20 &&
+	$height == 10 &&
+	$format == 'uchar' &&
+    $bands == 1) {
+	echo "pass";
+  }
+?>
+--EXPECT--
+pass

--- a/tests/038.phpt
+++ b/tests/038.phpt
@@ -7,9 +7,7 @@ can write to memory
   $byte_array = array_fill(0, 200, 0);
   $image = vips_image_new_from_memory($byte_array, 20, 10, 1, 'uchar');
   $mem_arr = vips_image_write_to_memory($image);
-  // var_dump($mem_arr);
 
-  // FIXME: Doesn't work.
   if ($byte_array === $mem_arr) {
     echo "pass";
   }

--- a/tests/038.phpt
+++ b/tests/038.phpt
@@ -5,7 +5,7 @@ can write to memory
 --FILE--
 <?php
   $byte_array = array_fill(0, 200, 0);
-  $image = vips_image_new_from_memory($byte_array, 20, 10, 1, 'uchar');
+  $image = vips_image_new_from_memory($byte_array, 20, 10, 1, 'uchar')["out"];
   $mem_arr = vips_image_write_to_memory($image);
 
   if ($byte_array === $mem_arr) {

--- a/tests/038.phpt
+++ b/tests/038.phpt
@@ -1,0 +1,18 @@
+--TEST--
+can write to memory
+--SKIPIF--
+<?php if (!extension_loaded("vips")) print "skip"; ?>
+--FILE--
+<?php
+  $byte_array = array_fill(0, 200, 0);
+  $image = vips_image_new_from_memory($byte_array, 20, 10, 1, 'uchar');
+  $mem_arr = vips_image_write_to_memory($image);
+  // var_dump($mem_arr);
+
+  // FIXME: Doesn't work.
+  if ($byte_array === $mem_arr) {
+    echo "pass";
+  }
+?>
+--EXPECT--
+pass

--- a/tests/038.phpt
+++ b/tests/038.phpt
@@ -4,11 +4,11 @@ can write to memory
 <?php if (!extension_loaded("vips")) print "skip"; ?>
 --FILE--
 <?php
-  $byte_array = array_fill(0, 200, 0);
-  $image = vips_image_new_from_memory($byte_array, 20, 10, 1, 'uchar')["out"];
-  $mem_arr = vips_image_write_to_memory($image);
+  $binary_str = pack("c*", ...array_fill(0, 200, 0));
+  $image = vips_image_new_from_memory($binary_str, 20, 10, 1, "uchar")["out"];
+  $mem_str = vips_image_write_to_memory($image);
 
-  if ($byte_array === $mem_arr) {
+  if ($binary_str === $mem_str) {
     echo "pass";
   }
 ?>

--- a/tests/038.phpt
+++ b/tests/038.phpt
@@ -4,7 +4,7 @@ can write to memory
 <?php if (!extension_loaded("vips")) print "skip"; ?>
 --FILE--
 <?php
-  $binary_str = pack("c*", ...array_fill(0, 200, 0));
+  $binary_str = pack("C*", ...array_fill(0, 200, 0));
   $image = vips_image_new_from_memory($binary_str, 20, 10, 1, "uchar")["out"];
   $mem_str = vips_image_write_to_memory($image);
 

--- a/vips.c
+++ b/vips.c
@@ -1456,6 +1456,7 @@ PHP_FUNCTION(vips_image_write_to_memory)
 	}
 
 	RETVAL_STRINGL((char *)arr, arr_len);
+	g_free(arr);
 }
 /* }}} */
 

--- a/vips.c
+++ b/vips.c
@@ -1375,8 +1375,7 @@ PHP_FUNCTION(vips_image_copy_memory)
 		RETURN_LONG(-1);
 	}
 
-	new_image = vips_image_copy_memory(image);
-	if (!new_image) {
+	if (!(new_image = vips_image_copy_memory(image))) {
 		RETURN_LONG(-1);
 	}
 
@@ -1386,6 +1385,78 @@ PHP_FUNCTION(vips_image_copy_memory)
 	resource = zend_register_resource(new_image, le_gobject);
 	ZVAL_RES(&zvalue, resource);
 	add_assoc_zval(return_value, "out", &zvalue);
+}
+/* }}} */
+
+/* {{{ proto resource vips_image_write_to_memory(array data, integer width, integer height, integer bands, string format)
+   Wrap an image around a memory array. */
+PHP_FUNCTION(vips_image_new_from_memory)
+{
+	zval *array;
+	long width;
+	long height;
+	long bands;
+	char *format;
+	size_t format_len;
+	int format_value;
+	VipsBandFormat band_format;
+	int array_count;
+	VipsImage *image;
+
+	VIPS_DEBUG_MSG("vips_image_new_from_memory:\n");
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "alllp",
+ 		&array, &width, &height, &bands, &format, &format_len) == FAILURE) {
+		RETURN_LONG(-1);
+	}
+
+	if ((format_value = vips_enum_from_nick("enum", VIPS_TYPE_BAND_FORMAT, format)) < 0) {
+		RETURN_LONG(-1);
+	}
+	band_format = format_value;
+
+	array_count = zend_hash_num_elements(Z_ARRVAL_P(array));
+	// FIXME: Can we pass the zval array like this?
+	// Or should we loop first?
+	if (!(image = vips_image_new_from_memory((void *) array, array_count, width, height,
+		bands, band_format))) {
+		RETURN_LONG(-1);
+	}
+
+	RETURN_RES(zend_register_resource(image, le_gobject));
+}
+/* }}} */
+
+/* {{{ proto array vips_image_write_to_memory(resource image)
+   Write an image to a memory array. */
+PHP_FUNCTION(vips_image_write_to_memory)
+{
+	zval *IM;
+	VipsImage *image;
+	size_t arr_len;
+	uint8_t *arr;
+
+	VIPS_DEBUG_MSG("vips_image_write_to_memory:\n");
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r", &IM) == FAILURE) {
+		RETURN_LONG(-1);
+	}
+
+	if ((image = (VipsImage *)zend_fetch_resource(Z_RES_P(IM),
+		"GObject", le_gobject)) == NULL) {
+		RETURN_LONG(-1);
+	}
+
+	if (!(arr = vips_image_write_to_memory(image, &arr_len))) {
+		RETURN_LONG(-1);
+	}
+
+	array_init(return_value);
+
+	int i;
+	for (i = 0; i < arr_len; i++) {
+		add_next_index_long(return_value, arr[i]);
+	}
 }
 /* }}} */
 
@@ -1922,6 +1993,18 @@ ZEND_BEGIN_ARG_INFO(arginfo_vips_image_copy_memory, 0)
 	ZEND_ARG_INFO(0, image)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO(arginfo_vips_image_new_from_memory, 0)
+	ZEND_ARG_INFO(0, array)
+	ZEND_ARG_INFO(0, width)
+	ZEND_ARG_INFO(0, height)
+	ZEND_ARG_INFO(0, bands)
+	ZEND_ARG_INFO(0, format)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO(arginfo_vips_image_write_to_memory, 0)
+	ZEND_ARG_INFO(0, image)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO(arginfo_vips_foreign_find_load, 0)
 	ZEND_ARG_INFO(0, filename)
 ZEND_END_ARG_INFO()
@@ -1990,6 +2073,8 @@ const zend_function_entry vips_functions[] = {
 	PHP_FE(vips_image_write_to_file, arginfo_vips_image_write_to_file)
 	PHP_FE(vips_image_write_to_buffer, arginfo_vips_image_write_to_buffer)
 	PHP_FE(vips_image_copy_memory, arginfo_vips_image_copy_memory)
+	PHP_FE(vips_image_new_from_memory, arginfo_vips_image_new_from_memory)
+	PHP_FE(vips_image_write_to_memory, arginfo_vips_image_write_to_memory)
 	PHP_FE(vips_foreign_find_load, arginfo_vips_foreign_find_load)
 	PHP_FE(vips_foreign_find_load_buffer, arginfo_vips_foreign_find_load_buffer)
 	PHP_FE(vips_interpolate_new, arginfo_vips_interpolate_new)

--- a/vips.c
+++ b/vips.c
@@ -1401,6 +1401,8 @@ PHP_FUNCTION(vips_image_new_from_memory)
 	int format_value;
 	VipsBandFormat band_format;
 	VipsImage *image;
+	zend_resource *resource;
+	zval zvalue;
 
 	VIPS_DEBUG_MSG("vips_image_new_from_memory:\n");
 
@@ -1431,7 +1433,12 @@ PHP_FUNCTION(vips_image_new_from_memory)
 		RETURN_LONG(-1);
 	}
 
-	RETURN_RES(zend_register_resource(image, le_gobject));
+	/* Return as an array for all OK, -1 for error.
+	 */
+	array_init(return_value);
+	resource = zend_register_resource(image, le_gobject);
+	ZVAL_RES(&zvalue, resource);
+	add_assoc_zval(return_value, "out", &zvalue);
 }
 /* }}} */
 

--- a/vips.c
+++ b/vips.c
@@ -1388,11 +1388,12 @@ PHP_FUNCTION(vips_image_copy_memory)
 }
 /* }}} */
 
-/* {{{ proto resource vips_image_write_to_memory(array data, integer width, integer height, integer bands, string format)
+/* {{{ proto resource vips_image_new_from_memory(string data, integer width, integer height, integer bands, string format)
    Wrap an image around a memory array. */
 PHP_FUNCTION(vips_image_new_from_memory)
 {
-	HashTable *ht;
+	char *bstr;
+	size_t bstr_len;
 	long width;
 	long height;
 	long bands;
@@ -1406,29 +1407,17 @@ PHP_FUNCTION(vips_image_new_from_memory)
 
 	VIPS_DEBUG_MSG("vips_image_new_from_memory:\n");
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "hlllp",
-		&ht, &width, &height, &bands, &format, &format_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "slllp",
+		&bstr, &bstr_len, &width, &height, &bands, &format, &format_len) == FAILURE) {
 		RETURN_LONG(-1);
 	}
 
-	if ((format_value = vips_enum_from_nick("enum", VIPS_TYPE_BAND_FORMAT, format)) < 0) {
+	if ((format_value = vips_enum_from_nick("php-vips", VIPS_TYPE_BAND_FORMAT, format)) < 0) {
 		RETURN_LONG(-1);
 	}
 	band_format = format_value;
 
-	const int size = zend_hash_num_elements(ht);
-	int arr[size];
-	int i;
-
-	for (i = 0; i < size; i++) {
-		zval *ele;
-
-		if ((ele = zend_hash_index_find(ht, i)) != NULL) {
-			arr[i] = zval_get_long(ele);
-		}
-	}
-
-	if (!(image = vips_image_new_from_memory_copy(arr, size, width, height, bands,
+	if (!(image = vips_image_new_from_memory_copy(bstr, bstr_len, width, height, bands,
 		band_format))) {
 		RETURN_LONG(-1);
 	}
@@ -1442,7 +1431,7 @@ PHP_FUNCTION(vips_image_new_from_memory)
 }
 /* }}} */
 
-/* {{{ proto array vips_image_write_to_memory(resource image)
+/* {{{ proto string vips_image_write_to_memory(resource image)
    Write an image to a memory array. */
 PHP_FUNCTION(vips_image_write_to_memory)
 {
@@ -1466,12 +1455,7 @@ PHP_FUNCTION(vips_image_write_to_memory)
 		RETURN_LONG(-1);
 	}
 
-	array_init(return_value);
-
-	int i;
-	for (i = 0; i < arr_len; i++) {
-		add_next_index_long(return_value, arr[i]);
-	}
+	RETVAL_STRINGL((char *)arr, arr_len);
 }
 /* }}} */
 


### PR DESCRIPTION
Implementation of `new_from_memory` / `write_to_memory`.  It can wrap an image around a memory array and write an image to a memory array.

~~However there seems to be something wrong with the passing the `zval` array to `vips_image_new_from_memory` because the image average returns random(?) values (`vips_image_new_from_memory_copy` doesn't fix this). Therefore I'm not sure whether writing to memory works (how should I test this without doing `new_from_memory` first?).~~

~~Next week I'll see if I can finish this. I've almost no experience in writing PHP extensions (and in general the C programming language) so my apologies if it takes longer.~~

<sup>(I've selected the `Allow edits from maintainers` option that allows you to make commits on this branch)</sup>

**Edit:**
All done! 🎉 